### PR TITLE
Normalize Supports Video Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ the originals that are a consistent size and format (jpg).
 
 `n` = "normalized", `t` = "thumbnail".
 
+_`ffmpeg` is required if there are ".mov" or ".mp4" files in <path>._
+
 ### farto fartos upload
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/trotttrotttrott/farto
 go 1.14
 
 require (
+	github.com/adrium/goheif v0.0.0-20210309200126-b184a7b446fa
 	github.com/aws/aws-sdk-go v1.30.24
 	github.com/disintegration/imaging v1.6.2
 	github.com/go-clix/cli v0.1.1
-	github.com/jdeng/goheif v0.0.0-20200323230657-a0d6a8b3e68f
 	github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/adrium/goheif v0.0.0-20210309200126-b184a7b446fa h1:ISwtQHwIaKiwhFFmBOIib1o1jH3UvtKPnsEo45zsVj0=
+github.com/adrium/goheif v0.0.0-20210309200126-b184a7b446fa/go.mod h1:aKVJoQ0cc9K5Xb058XSnnAxXLliR97qbSqWBlm5ca1E=
 github.com/aws/aws-sdk-go v1.30.24 h1:y3JPD51VuEmVqN3BEDVm4amGpDma2cKJcDPuAU1OR58=
 github.com/aws/aws-sdk-go v1.30.24/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
@@ -11,8 +13,6 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/jdeng/goheif v0.0.0-20200323230657-a0d6a8b3e68f h1:jYkcRYsnnvPF07yn4XJx3k8duM4KDw3QYB3p8bUrk80=
-github.com/jdeng/goheif v0.0.0-20200323230657-a0d6a8b3e68f/go.mod h1:G7IyA3/eR9IFmUIPdyP3c0l4ZaqEvXAk876WfaQ8plc=
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -25,7 +25,6 @@ github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/pkg/farto/fartos.go
+++ b/pkg/farto/fartos.go
@@ -14,8 +14,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 
+	"github.com/adrium/goheif"
 	"github.com/disintegration/imaging"
-	"github.com/jdeng/goheif"
 	"github.com/rwcarlsen/goexif/exif"
 )
 

--- a/pkg/farto/fartos.go
+++ b/pkg/farto/fartos.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"image"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -43,6 +44,20 @@ func FartosNormalize(p string) error {
 		var src image.Image
 
 		switch strings.ToLower(path.Ext(info.Name())) {
+
+		case ".mov", ".mp4":
+			cmd := exec.Command("ffmpeg", "-i", p, "-frames:v", "1", "-")
+			var buff bytes.Buffer
+			cmd.Stdout = &buff
+			err := cmd.Run()
+			if err != nil {
+				return err
+			}
+			src, _, err = image.Decode(bytes.NewReader(buff.Bytes()))
+			if err != nil {
+				return err
+			}
+
 		case ".heic":
 			f, err := os.Open(p)
 			if err != nil {
@@ -89,6 +104,7 @@ func FartosNormalize(p string) error {
 					src = imaging.Transverse(src)
 				}
 			}
+
 		default:
 			src, err = imaging.Open(p, imaging.AutoOrientation(true))
 			if err != nil {

--- a/pkg/farto/fartos.go
+++ b/pkg/farto/fartos.go
@@ -37,7 +37,7 @@ func FartosNormalize(p string) error {
 
 	err := filepath.Walk(p, func(p string, info os.FileInfo, err error) error {
 
-		if !info.IsDir() {
+		if info.IsDir() {
 			return nil // don't bother with recursion
 		}
 

--- a/pkg/farto/fartos.go
+++ b/pkg/farto/fartos.go
@@ -32,6 +32,7 @@ func FartosNormalize(p string) error {
 		if err != nil {
 			return err
 		}
+		delete(versions, dirSuffix)
 		versions[dir] = size
 	}
 
@@ -46,14 +47,15 @@ func FartosNormalize(p string) error {
 		switch strings.ToLower(path.Ext(info.Name())) {
 
 		case ".mov", ".mp4":
-			cmd := exec.Command("ffmpeg", "-i", p, "-frames:v", "1", "-")
-			var buff bytes.Buffer
-			cmd.Stdout = &buff
+			cmd := exec.Command("ffmpeg", "-i", p, "-frames:v", "1", "-f", "image2", "-")
+			var outb, errb bytes.Buffer
+			cmd.Stdout = &outb
+			cmd.Stderr = &errb
 			err := cmd.Run()
 			if err != nil {
-				return err
+				return fmt.Errorf("%w\n%s", err, errb.String())
 			}
-			src, _, err = image.Decode(bytes.NewReader(buff.Bytes()))
+			src, _, err = image.Decode(bytes.NewReader(outb.Bytes()))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
`farto fartos normalize <path>` supports `.mov` and `.mp4` files. It creates jpegs of the first frame.